### PR TITLE
Change exhaust category from VMT_DOOR_L to VMT_EXHAUST.

### DIFF
--- a/BackToTheFutureV/TimeMachineClasses/Handlers/BaseHandlers/ModsHandler.cs
+++ b/BackToTheFutureV/TimeMachineClasses/Handlers/BaseHandlers/ModsHandler.cs
@@ -71,7 +71,7 @@ namespace BackToTheFutureV
             WheelType wheelType = (WheelType)Vehicle.Mods[VehicleModType.FrontWheel].Index;
             ReactorType reactorType = (ReactorType)Vehicle.Mods[VehicleModType.Plaques].Index;
             PlateType plateType = (PlateType)Vehicle.Mods[VehicleModType.Ornaments].Index;
-            ExhaustType exhaustType = (ExhaustType)Vehicle.Mods[VehicleModType.Windows].Index;
+            ExhaustType exhaustType = (ExhaustType)Vehicle.Mods[VehicleModType.Exhaust].Index;
             HoodType hoodType = (HoodType)Vehicle.Mods[VehicleModType.Hood].Index;
             ModState modState = (ModState)Vehicle.Mods[VehicleModType.Spoilers].Index;
             HookState hookState = HookState.Unknown;

--- a/BackToTheFutureV/Vehicles/DMC12/DMC12Mods.cs
+++ b/BackToTheFutureV/Vehicles/DMC12/DMC12Mods.cs
@@ -248,7 +248,7 @@ namespace BackToTheFutureV
 
                 if (IsDMC12)
                 {
-                    Vehicle.Mods[VehicleModType.Windows].Index = (int)value;
+                    Vehicle.Mods[VehicleModType.Exhaust].Index = (int)value;
                 }
             }
         }

--- a/BackToTheFutureV/Vehicles/DMC12/DMC12Mods.cs
+++ b/BackToTheFutureV/Vehicles/DMC12/DMC12Mods.cs
@@ -36,9 +36,10 @@ namespace BackToTheFutureV
 
                 Vehicle.Mods.PrimaryColor = VehicleColor.BrushedAluminium;
                 Vehicle.Mods.SecondaryColor = VehicleColor.MetallicBlackSteel;
-                Vehicle.Mods.TrimColor = VehicleColor.PureWhite;
+                Vehicle.Mods.TrimColor = VehicleColor.PureWhite; // Gray Interior
 
                 Function.Call(Hash.SET_VEHICLE_ENVEFF_SCALE, Vehicle, 0f);
+                Vehicle.DirtLevel = 0f;
 
                 //Seats
                 Vehicle.Mods[VehicleModType.VanityPlates].Index = 0;

--- a/RPF/common/data/carcols.meta
+++ b/RPF/common/data/carcols.meta
@@ -259,7 +259,7 @@
 						<Item>exhaust</Item>
 						<Item>exhaust_2</Item>
 					</turnOffBones>
-					<type>VMT_DOOR_L</type>
+					<type>VMT_EXHAUST</type>
 					<bone>misc_o</bone>
 					<collisionBone>chassis</collisionBone>
 					<cameraPos>VMCP_DEFAULT</cameraPos>
@@ -490,7 +490,7 @@
 						<Item>exhaust</Item>
 						<Item>exhaust_2</Item>
 					</turnOffBones>
-					<type>VMT_DOOR_L</type>
+					<type>VMT_EXHAUST</type>
 					<bone>chassis</bone>
 					<collisionBone>chassis</collisionBone>
 					<cameraPos>VMCP_DEFAULT</cameraPos>

--- a/RPF/common/data/levels/gta5/vehicles.meta
+++ b/RPF/common/data/levels/gta5/vehicles.meta
@@ -41,7 +41,7 @@
 			<PovCameraVerticalAdjustmentForRollCage value="0.000000"/>
 			<PovPassengerCameraOffset x="0.000000" y="0.000000" z="0.000000"/>
 			<PovRearPassengerCameraOffset x="0.000000" y="0.000000" z="0.000000"/>
-			<vfxInfoName>VFXVEHICLEINFO_CAR_DELUXO</vfxInfoName>
+			<vfxInfoName>VFXVEHICLEINFO_CAR_DMC12</vfxInfoName>
 			<shouldUseCinematicViewMode value="true"/>
 			<shouldCameraTransitionOnClimbUpDown value="false"/>
 			<shouldCameraIgnoreExiting value="false"/>

--- a/XML/vfxvehicleinfo.ymt.xml
+++ b/XML/vfxvehicleinfo.ymt.xml
@@ -1,0 +1,15664 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- This goes to update/update.rpf/x64/data/effects, use OpenIV to import it, CodeWalker uses a different format? (I'm not too sure, but I know it won't work.) for PSO files. -->
+<CVfxVehicleInfoMgr>
+  <vfxVehicleInfos>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BICYCLE_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.40000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="0.40000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.25000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel_bike</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="false"/>
+      <wreckedFirePtFxName>none</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bicycle_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bicycle_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_bicycle_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bicycle_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_DINGHY">
+      <mtlBangPtFxVehicleEvo value="0.25000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.70000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="150.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="5.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.70000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Dinghy_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_boat_Dinghy_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="3.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="5.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.10000000"/>
+      <boatBowPtFxReverseOffset value="1.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.50000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="8.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="150.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="150.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="5.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.25000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_boat_Dinghy_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="3.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="5.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.10000000"/>
+      <boatBowPtFxReverseOffset value="0.20000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.50000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_JETMAX">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="10.00000000"/>
+      <boatEntryPtFxScale value="1.35000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_jetmax_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_jetmax_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_boat_Dinghy_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="3.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="5.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="15.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="0.72500000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="10.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.20000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_MARQUIS">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="3.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="10.00000000"/>
+      <boatEntryPtFxScale value="1.80000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Marques_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.05000000"/>
+      <boatBowPtFxSpeedEvoMax value="5.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="0.80000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="10.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.20000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_SUNTRAP">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="10.00000000"/>
+      <boatEntryPtFxScale value="1.25000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Suntrap_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_boat_Dinghy_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="3.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="1.50000000"/>
+      <boatBowPtFxSpeedEvoMax value="7.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="0.72500000"/>
+      <boatBowPtFxReverseOffset value="0.20000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="10.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.20000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_TROPIC">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="10.00000000"/>
+      <boatEntryPtFxScale value="1.25000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Tropic_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="1.50000000"/>
+      <boatBowPtFxSpeedEvoMax value="7.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="0.72500000"/>
+      <boatBowPtFxReverseOffset value="0.25000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="10.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.20000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BOAT_TUG">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.90000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_tug</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="10.00000000"/>
+      <exhaustPtFxTempEvoMin value="20.00000000"/>
+      <exhaustPtFxTempEvoMax value="50.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="150.00000000"/>
+      <boatEntryPtFxName>water_boat_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="3.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="10.00000000"/>
+      <boatEntryPtFxScale value="1.80000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_boat_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="300.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Marques_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.05000000"/>
+      <boatBowPtFxSpeedEvoMax value="5.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="0.80000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="10.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="300.00000000"/>
+      <boatPropellerPtFxName>water_boat_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.20000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="200.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BULLDOZER">
+      <mtlBangPtFxVehicleEvo value="0.65000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck_rig</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_tank</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="3"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="true"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="10.00000000"/>
+      <wheelFrictionPtFxFricMult value="10.00000000"/>
+      <wheelDisplacementPtFxDispMult value="10.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_BUS_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.80000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.80000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bus</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_bus</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="-1.50000000" z="0.50000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_bus</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="-5.00000000" z="0.50000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_AMPHIBIOUS">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_amph_car_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.50000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="150.00000000"/>
+      <boatBowPtFxForwardName>water_amph_car_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_amph_car_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_amph_car_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="2.00000000" z="0.20000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="150.00000000"/>
+      <boatPropellerPtFxName>water_amph_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="0.90000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="140.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="0.75000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_BULLET">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bullet</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car_bullet</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_DELUXO">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_xm_deluxo_engine_glow</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_xm_deluxo_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_xm_deluxo_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_xm_deluxo_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_xm_deluxo_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_xm_deluxo_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="25.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+	<!-- begin added by bttfv -->
+	<Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_DMC12">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_xm_deluxo_engine_glow</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_xm_deluxo_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_xm_deluxo_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_xm_deluxo_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_xm_deluxo_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_xm_deluxo_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="25.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <!-- end addded by bttfv -->
+	<Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_ELECTRIC">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_GENERIC_SMALL">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_sm_car_small_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_HOTKNIFE">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_panel_open_carHK</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_OFFROAD">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_CAR_STROMBERG">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_amph_car_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.50000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="150.00000000"/>
+      <boatBowPtFxForwardName>water_amph_car_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_amph_car_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_amph_car_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="2.00000000" z="0.20000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="150.00000000"/>
+      <boatPropellerPtFxName>veh_prop_stromberg</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="-6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="0.90000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="140.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="0.75000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>veh_xm_strom_underwater_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_FORKLIFT">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_GOLF_CAR">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="0.30000000"/>
+      <wheelSkidmarkPressureMult value="0.10000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.50000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_HELI_ANNIHILATOR">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_heli</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli_anh</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="70.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="1.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_HELI_CARGOBOB">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_heli_cargobob</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_heli_cargobob_misfire</misfirePtFxName>
+      <misfirePtFxRange value="300.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli_cargobob</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="700.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="1.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_HELI_FROGGER">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_heli</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli_frogger</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="100.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="1.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_HELI_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_heli</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="200.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="1.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_HELI_SKYLIFT">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_heli_skylift</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_heli_misfire</misfirePtFxName>
+      <misfirePtFxRange value="300.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli_skylift</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="700.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="1.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_JETSKI_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.80000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.70000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_boat</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_boat</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_boat</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="45.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_boat</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_jetski_entry2</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.50000000"/>
+      <boatExitPtFxEnabled value="true"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName>water_jetski_exit</boatExitPtFxName>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="150.00000000"/>
+      <boatBowPtFxForwardName>water_jetski_bow1</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_jetski_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_jetski_bow1_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="2.00000000" z="0.20000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="150.00000000"/>
+      <boatPropellerPtFxName>water_jetski_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="0.90000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="140.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="0.75000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_MOTORBIKE_FAGGIO">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.60000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_faggio_exhaust</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start_bike</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="0.75000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_MOTORBIKE_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.60000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start_bike</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="0.75000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_MOTORBIKE_OPPRESSOR">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.60000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start_bike</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="0.75000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_ba_oppressor_engine_glow</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_ba_oppressor_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_ba_oppressor_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_ba_oppressor_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_ba_oppressor_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_ba_oppressor_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="25.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_MOTORBIKE_SANCTUS">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="0.60000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_sanctus_exhaust</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_sanctus_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_sanctus_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="0.75000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_ALKONOST">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_vulkan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="0.80000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_lazer</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_ih_exhaust_afterburner_alk</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_AVENGER">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_xm_vent_plane_avenger</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="1.25000000" y="2.50000000" z="2.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-1.25000000" y="2.50000000" z="2.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="5.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_xm_avenger_downwash_default</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_xm_avenger_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_xm_avenger_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_xm_avenger_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_xm_avenger_downwash_vegetation</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="10.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_BOMBUSHKA">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_titan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="3000.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="800.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="500.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_bom</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="800.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="4.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="7.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="3.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane_cockpit</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="2.00000000" y="-3.25000000" z="3.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane_cockpit</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="40.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-2.00000000" y="-2.70000000" z="3.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="500.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip_cargo</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="1000.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="5.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="30.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="80.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_CARGO">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="1.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_cargo</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="3000.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="800.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="500.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="800.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="4.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="10.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane_cockpit</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane_cockpit</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="500.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip_cargo</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="1000.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="5.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="30.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="200.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_CUBAN800">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_cuban800</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="-0.60000000" y="1.00000000" z="-0.55000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.60000000" y="1.00000000" z="-0.55000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="90.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_DODO">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_duster</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="5.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_DUSTER">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_duster</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="90.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_MAMMATUS">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="2.35000000" z="0.40000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.50000000" y="2.25000000" z="0.50000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_MOGUL">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_cuban800</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="90.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_MOLOTOK">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_vulkan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="0.80000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_lazer</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_exhaust_afterburner_molotok</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_PYRO">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_vulkan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="0.80000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_lazer</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_exhaust_afterburner_pyro</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_SEABREEZE">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_seabreeze_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="5.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="15.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_STARLING">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_starling</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_starling</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_afterburner_starling</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_STRIKEFORCE">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_strikeforce</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_lazer</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_exhaust_afterburner</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_TITAN">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_titan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="3000.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="800.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="500.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_titan</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="800.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="4.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="7.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="3.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane_cockpit</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="2.00000000" y="-3.25000000" z="3.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane_cockpit</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="40.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-2.00000000" y="-2.70000000" z="3.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="500.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip_cargo</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="1000.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="5.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="30.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="80.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_TULA">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_plane</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_tula</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_tula_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="5.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="15.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_VELUM">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_velum</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_plane_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="160.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="2.35000000" z="0.40000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.50000000" y="2.25000000" z="0.50000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="160.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_VOLATOL">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_titan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="3000.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="800.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="500.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_volatol</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="800.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="4.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="7.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="3.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane_cockpit</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="2.00000000" y="-3.25000000" z="3.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane_cockpit</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="40.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-2.00000000" y="-2.70000000" z="3.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="500.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip_cargo</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="1000.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="5.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="30.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="80.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="160.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_PLANE_VULKAN">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_vulkan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_plane_lazer</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_plane_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_exhaust_afterburner</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="true"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="true"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="50.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_QUAD_AMPHIBIOUS">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start_bike</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="2.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_amph_quad_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.50000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="150.00000000"/>
+      <boatBowPtFxForwardName>water_amph_quad_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_amph_quad_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_amph_quad_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="2.00000000" z="0.20000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="150.00000000"/>
+      <boatPropellerPtFxName>water_amph_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="0.90000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="140.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="0.75000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_QUAD_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start_bike</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_bike</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak_bike</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="2"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="2.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="0.40000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_bike</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="15.00000000"/>
+      <wreckedFirePtFxDurationMax value="35.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_bike</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_bike_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="2.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="5.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="5.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_bike_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="150.00000000"/>
+      <splashWadePtFxName>water_splash_bike_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_bike_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_RC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_rc</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture_rc</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_rc</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>none</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_RC_TANK">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_vent_rc</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="3"/>
+      <wheelGenericDecalSet value="3"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="true"/>
+      <wheelSkidmarkSlipMult value="100.00000000"/>
+      <wheelSkidmarkPressureMult value="50000.00000000"/>
+      <wheelFrictionPtFxFricMult value="50000.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.00000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>none</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_SPACECRAFT_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_spacecraft</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20000.00000000"/>
+      <exhaustPtFxRange value="3000.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="true"/>
+      <engineDamagePtFxNoPanelName>veh_vent_heli</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="70.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_heli</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_heli</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_heli</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_heli</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="100.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_SUBMARINE">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="150.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="false"/>
+      <wreckedFirePtFxName>none</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="180.00000000"/>
+      <boatEntryPtFxName>water_boat_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="180.00000000"/>
+      <boatBowPtFxForwardName>water_boat_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="180.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="200.00000000"/>
+      <boatPropellerPtFxName>veh_prop_sub</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="-6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="4.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="180.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="180.00000000"/>
+      <splashInPtFxName>water_splash_sub_null_trig</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="1.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="1.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="8.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="1.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="8.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="180.00000000"/>
+      <splashOutPtFxName>water_splash_sub_null_trig</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="1.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="8.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="1.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="8.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="180.00000000"/>
+      <splashWadePtFxName>water_splash_sub_null_loop</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="2.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="8.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="2.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="8.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="180.00000000"/>
+      <splashTrailPtFxName>water_splash_sub_null_loop</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="8.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_SUBMERSIBLE">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="150.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="false"/>
+      <wreckedFirePtFxName>none</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_boat_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName>water_boat_Dinghy_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_boat_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="true"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="500.00000000"/>
+      <boatPropellerPtFxName>veh_prop_submersible</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="-6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="4.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_sub_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_sub_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_sub_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TANK_RHINO">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="1.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck_rig</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_tank</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="3"/>
+      <wheelGenericDecalSet value="3"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="true"/>
+      <wheelSkidmarkSlipMult value="100.00000000"/>
+      <wheelSkidmarkPressureMult value="50000.00000000"/>
+      <wheelFrictionPtFxFricMult value="50000.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_tank_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_tank</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="-0.75000000" y="-0.20000000" z="1.35000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_tank</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.20000000" y="-3.50000000" z="0.50000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TANK_SCARAB">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="1.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck_rig</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_tank</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="3"/>
+      <wheelGenericDecalSet value="3"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="true"/>
+      <wheelSkidmarkSlipMult value="100.00000000"/>
+      <wheelSkidmarkPressureMult value="50000.00000000"/>
+      <wheelFrictionPtFxFricMult value="50000.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_tank_cockpit</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.50000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_tank</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.20000000" y="-2.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_petroltank_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.20000000" y="-3.50000000" z="0.50000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_THRUSTER">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>veh_exhaust_vulkan</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="300.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_exhaust_plane_misfire</misfirePtFxName>
+      <misfirePtFxRange value="160.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>veh_xm_thruster_engine_damage</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="300.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>veh_xm_thruster_wreck_fire</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_plane</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="true"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_plane</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_plane</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="true"/>
+      <planeAfterburnerPtFxName>veh_xm_thruster_afterburner</planeAfterburnerPtFxName>
+      <planeAfterburnerPtFxRange value="3000.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="true"/>
+      <planeWingTipPtFxName>veh_wingtip</planeWingTipPtFxName>
+      <planeWingTipPtFxRange value="150.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="30.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="60.00000000"/>
+      <planeDamageFirePtFxEnabled value="true"/>
+      <planeDamageFirePtFxName>veh_air_debris</planeDamageFirePtFxName>
+      <planeDamageFirePtFxRange value="500.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault>veh_air_turbulance_default</planeGroundDisturbPtFxNameDefault>
+      <planeGroundDisturbPtFxNameSand>veh_air_turbulance_sand</planeGroundDisturbPtFxNameSand>
+      <planeGroundDisturbPtFxNameDirt>veh_air_turbulance_dirt</planeGroundDisturbPtFxNameDirt>
+      <planeGroundDisturbPtFxNameWater>veh_air_turbulance_water</planeGroundDisturbPtFxNameWater>
+      <planeGroundDisturbPtFxNameFoliage>veh_air_turbulance_foliage</planeGroundDisturbPtFxNameFoliage>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="50.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="10.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="60.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName>veh_plane_damage</aircraftSectionDamageSmokePtFxName>
+      <aircraftSectionDamageSmokePtFxRange value="50.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="true"/>
+      <aircraftDownwashPtFxNameDefault>veh_xm_thruster_downwash</aircraftDownwashPtFxNameDefault>
+      <aircraftDownwashPtFxNameSand>veh_xm_thruster_downwash_sand</aircraftDownwashPtFxNameSand>
+      <aircraftDownwashPtFxNameDirt>veh_xm_thruster_downwash_dirt</aircraftDownwashPtFxNameDirt>
+      <aircraftDownwashPtFxNameWater>veh_xm_thruster_downwash_water</aircraftDownwashPtFxNameWater>
+      <aircraftDownwashPtFxNameFoliage>veh_xm_thruster_downwash_foliage</aircraftDownwashPtFxNameFoliage>
+      <aircraftDownwashPtFxRange value="50.00000000"/>
+      <aircraftDownwashPtFxDist value="10.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="3.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_plane_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_plane_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_plane_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_plane_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_BALE">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.10000000" y="-4.50000000" z="0.20000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.30000000" y="2.20000000" z="0.40000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.10000000" y="-6.20000000" z="-0.90000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.30000000" y="5.70000000" z="-0.90000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_GRAIN">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="-0.30000000" y="2.20000000" z="0.40000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.30000000" y="2.20000000" z="0.40000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_HOME">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_trailer_chimney</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="150.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="false"/>
+      <wreckedFirePtFxName>none</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>none</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="10.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_LOG">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.10000000" y="-5.20000000" z="-0.90000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.30000000" y="3.50000000" z="-0.20000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_SMALL">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="-0.30000000" y="5.70000000" z="-0.90000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAILER_TANKER">
+      <mtlBangPtFxVehicleEvo value="0.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="10.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="3.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="false"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="2.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.10000000" y="-5.80000000" z="-0.70000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="40.00000000"/>
+      <wreckedFire3PtFxRadius value="2.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.10000000" y="-4.00000000" z="1.25000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="1.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="1.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRAIN_GENERIC">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName>none</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="0.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="12.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName>veh_exhaust_misfire</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="false"/>
+      <engineDamagePtFxHasPanel value="false"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>none</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>none</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="40.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="false"/>
+      <leakPtFxOilName>none</leakPtFxOilName>
+      <leakPtFxPetrolName>none</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_train</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.70000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_train</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.50000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="-1.50000000" z="1.00000000"/>
+      <wreckedFire3PtFxEnabled value="true"/>
+      <wreckedFire3PtFxName>fire_wrecked_train</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.50000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="-5.00000000" z="1.20000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>_water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>_water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="false"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>_water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="false"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>_water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_APC">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="1.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="false"/>
+      <exhaustPtFxName/>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="false"/>
+      <engineStartupPtFxName/>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName/>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="2.50000000" z="0.70000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="true"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName>water_amph_car_entry</boatEntryPtFxName>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="15.00000000"/>
+      <boatEntryPtFxScale value="1.50000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="true"/>
+      <boatBowPtFxRange value="150.00000000"/>
+      <boatBowPtFxForwardName>water_amph_car_bow</boatBowPtFxForwardName>
+      <boatBowPtFxReverseName>water_amph_car_rev</boatBowPtFxReverseName>
+      <boatBowPtFxForwardMountedName>water_amph_car_bow_mounted</boatBowPtFxForwardMountedName>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="2.00000000" z="0.20000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="15.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.25000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="150.00000000"/>
+      <boatWashPtFxName>water_boat_wash</boatWashPtFxName>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="true"/>
+      <boatPropellerPtFxRange value="150.00000000"/>
+      <boatPropellerPtFxName>water_amph_prop</boatPropellerPtFxName>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="0.90000000"/>
+      <boatLowLodWakePtFxEnabled value="true"/>
+      <boatLowLodWakePtFxRangeMin value="140.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="1500.00000000"/>
+      <boatLowLodWakePtFxName>water_boat_LOD</boatLowLodWakePtFxName>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="0.75000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_GENERIC">
+      <mtlBangPtFxVehicleEvo value="0.30000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.65000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_HIDDEN_EXHAUST">
+      <mtlBangPtFxVehicleEvo value="0.50000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.75000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_hidden</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="8.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="false"/>
+      <misfirePtFxName>veh_backfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="30.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="1.80000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName/>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="45.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName/>
+      <wreckedFire3PtFxDurationMin value="25.00000000"/>
+      <wreckedFire3PtFxDurationMax value="45.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="false"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="false"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="false"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="80.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_OFFROAD">
+      <mtlBangPtFxVehicleEvo value="0.35000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.35000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_RIG">
+      <mtlBangPtFxVehicleEvo value="1.00000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="1.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_truck_rig</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="2000.00000000"/>
+      <exhaustPtFxRange value="60.00000000"/>
+      <exhaustPtFxScale value="1.00000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="3.00000000"/>
+      <exhaustPtFxTempEvoMin value="100.00000000"/>
+      <exhaustPtFxTempEvoMax value="100.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="true"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="false"/>
+      <backfirePtFxName>none</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_truck</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_truck</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName/>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="2"/>
+      <wheelGenericRangeMult value="2.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="1.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_truck</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.20000000"/>
+      <wreckedFire2PtFxEnabled value="false"/>
+      <wreckedFire2PtFxName>fire_wrecked_truck_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="2.50000000" z="0.70000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_truck_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_truck</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="15.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="15.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="15.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="0.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="12.00000000"/>
+    </Item>
+    <Item type="CVfxVehicleInfo" key="VFXVEHICLEINFO_TRUCK_YOSEMITE2">
+      <mtlBangPtFxVehicleEvo value="0.10000000"/>
+      <mtlBangPtFxVehicleScale value="1.00000000"/>
+      <mtlScrapePtFxVehicleEvo value="0.00000000"/>
+      <mtlScrapePtFxVehicleScale value="1.00000000"/>
+      <exhaustPtFxEnabled value="true"/>
+      <exhaustPtFxName>veh_exhaust_car</exhaustPtFxName>
+      <exhaustPtFxCutOffSpeed value="20.00000000"/>
+      <exhaustPtFxRange value="20.00000000"/>
+      <exhaustPtFxScale value="0.80000000"/>
+      <exhaustPtFxSpeedEvoMin value="0.00000000"/>
+      <exhaustPtFxSpeedEvoMax value="5.00000000"/>
+      <exhaustPtFxTempEvoMin value="0.00000000"/>
+      <exhaustPtFxTempEvoMax value="35.00000000"/>
+      <exhaustPtFxThrottleEvoOnGearChange value="false"/>
+      <engineStartupPtFxEnabled value="true"/>
+      <engineStartupPtFxName>veh_exhaust_start</engineStartupPtFxName>
+      <engineStartupPtFxRange value="30.00000000"/>
+      <misfirePtFxEnabled value="true"/>
+      <misfirePtFxName>veh_exhaust_misfire</misfirePtFxName>
+      <misfirePtFxRange value="30.00000000"/>
+      <backfirePtFxEnabled value="true"/>
+      <backfirePtFxName>veh_backfire</backfirePtFxName>
+      <backfirePtFxRange value="30.00000000"/>
+      <engineDamagePtFxEnabled value="true"/>
+      <engineDamagePtFxHasPanel value="true"/>
+      <engineDamagePtFxHasRotorEvo value="false"/>
+      <engineDamagePtFxNoPanelName>none</engineDamagePtFxNoPanelName>
+      <engineDamagePtFxPanelOpenName>veh_panel_open_car</engineDamagePtFxPanelOpenName>
+      <engineDamagePtFxPanelShutName>veh_panel_shut_car</engineDamagePtFxPanelShutName>
+      <engineDamagePtFxRange value="150.00000000"/>
+      <engineDamagePtFxSpeedEvoMin value="0.00000000"/>
+      <engineDamagePtFxSpeedEvoMax value="10.00000000"/>
+      <overturnedSmokePtFxEnabled value="false"/>
+      <overturnedSmokePtFxName>veh_overturned_exhaust</overturnedSmokePtFxName>
+      <overturnedSmokePtFxRange value="50.00000000"/>
+      <overturnedSmokePtFxAngleThresh value="-0.70000000"/>
+      <overturnedSmokePtFxSpeedThresh value="1.00000000"/>
+      <overturnedSmokePtFxEngineHealthThresh value="400.00000000"/>
+      <leakPtFxEnabled value="true"/>
+      <leakPtFxOilName>veh_oil_leak</leakPtFxOilName>
+      <leakPtFxPetrolName>veh_petrol_leak</leakPtFxPetrolName>
+      <leakPtFxRange value="60.00000000"/>
+      <leakPtFxSpeedEvoMin value="0.00000000"/>
+      <leakPtFxSpeedEvoMax value="25.00000000"/>
+      <wheelGenericPtFxSet value="1"/>
+      <wheelGenericDecalSet value="1"/>
+      <wheelGenericRangeMult value="1.00000000"/>
+      <wheelSkidmarkRearOnly value="false"/>
+      <wheelSkidmarkSlipMult value="1.00000000"/>
+      <wheelSkidmarkPressureMult value="1.00000000"/>
+      <wheelFrictionPtFxFricMult value="2.00000000"/>
+      <wheelDisplacementPtFxDispMult value="1.00000000"/>
+      <wheelBurnoutPtFxFricMult value="1.00000000"/>
+      <wheelBurnoutPtFxTempMult value="1.00000000"/>
+      <wheelLowLodPtFxScale value="1.00000000"/>
+      <wheelPuncturePtFxName>veh_wheel_puncture</wheelPuncturePtFxName>
+      <wheelPuncturePtFxRange value="25.00000000"/>
+      <wheelBurstPtFxName>veh_wheel_burst</wheelBurstPtFxName>
+      <wheelBurstPtFxRange value="60.00000000"/>
+      <wheelFirePtFxName>fire_wheel</wheelFirePtFxName>
+      <wheelFirePtFxRange value="60.00000000"/>
+      <wheelFirePtFxSpeedEvoMin value="0.00000000"/>
+      <wheelFirePtFxSpeedEvoMax value="5.00000000"/>
+      <wreckedFirePtFxEnabled value="true"/>
+      <wreckedFirePtFxName>fire_wrecked_car</wreckedFirePtFxName>
+      <wreckedFirePtFxDurationMin value="25.00000000"/>
+      <wreckedFirePtFxDurationMax value="40.00000000"/>
+      <wreckedFirePtFxRadius value="2.00000000"/>
+      <wreckedFire2PtFxEnabled value="true"/>
+      <wreckedFire2PtFxName>fire_wrecked_car_vent</wreckedFire2PtFxName>
+      <wreckedFire2PtFxDurationMin value="25.00000000"/>
+      <wreckedFire2PtFxDurationMax value="40.00000000"/>
+      <wreckedFire2PtFxRadius value="1.00000000"/>
+      <wreckedFire2UseOverheatBone value="false"/>
+      <wreckedFire2OffsetPos x="0.50000000" y="0.00000000" z="0.00000000"/>
+      <wreckedFire3PtFxEnabled value="false"/>
+      <wreckedFire3PtFxName>fire_wrecked_car_vent</wreckedFire3PtFxName>
+      <wreckedFire3PtFxDurationMin value="15.00000000"/>
+      <wreckedFire3PtFxDurationMax value="20.00000000"/>
+      <wreckedFire3PtFxRadius value="1.00000000"/>
+      <wreckedFire3UseOverheatBone value="true"/>
+      <wreckedFire3OffsetPos x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <petrolTankFirePtFxName>fire_petroltank_car</petrolTankFirePtFxName>
+      <petrolTankFirePtFxRange value="60.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMin value="0.00000000"/>
+      <petrolTankFirePtFxSpeedEvoMax value="5.00000000"/>
+      <petrolTankFirePtFxRadius value="0.60000000"/>
+      <boatEntryPtFxEnabled value="false"/>
+      <boatEntryPtFxRange value="40.00000000"/>
+      <boatEntryPtFxName/>
+      <boatEntryPtFxSpeedEvoMin value="0.00000000"/>
+      <boatEntryPtFxSpeedEvoMax value="20.00000000"/>
+      <boatEntryPtFxScale value="1.00000000"/>
+      <boatExitPtFxEnabled value="false"/>
+      <boatExitPtFxRange value="40.00000000"/>
+      <boatExitPtFxName/>
+      <boatExitPtFxSpeedEvoMin value="0.00000000"/>
+      <boatExitPtFxSpeedEvoMax value="20.00000000"/>
+      <boatExitPtFxScale value="1.00000000"/>
+      <boatBowPtFxEnabled value="false"/>
+      <boatBowPtFxRange value="40.00000000"/>
+      <boatBowPtFxForwardName/>
+      <boatBowPtFxReverseName/>
+      <boatBowPtFxForwardMountedName/>
+      <boatBowPtFxForwardMountedOffset x="0.00000000" y="0.00000000" z="0.00000000"/>
+      <boatBowPtFxSpeedEvoMin value="0.00000000"/>
+      <boatBowPtFxSpeedEvoMax value="20.00000000"/>
+      <boatBowPtFxKeelEvoMin value="20.00000000"/>
+      <boatBowPtFxKeelEvoMax value="200.00000000"/>
+      <boatBowPtFxScale value="1.00000000"/>
+      <boatBowPtFxReverseOffset value="0.00000000"/>
+      <boatWashPtFxEnabled value="false"/>
+      <boatWashPtFxRange value="40.00000000"/>
+      <boatWashPtFxName/>
+      <boatWashPtFxSpeedEvoMin value="0.00000000"/>
+      <boatWashPtFxSpeedEvoMax value="20.00000000"/>
+      <boatWashPtFxScale value="1.00000000"/>
+      <boatPropellerPtFxEnabled value="false"/>
+      <boatPropellerPtFxRange value="40.00000000"/>
+      <boatPropellerPtFxName/>
+      <boatPropellerPtFxForwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxForwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMin value="0.00000000"/>
+      <boatPropellerPtFxBackwardSpeedEvoMax value="6.00000000"/>
+      <boatPropellerPtFxDepthEvoMin value="0.00000000"/>
+      <boatPropellerPtFxDepthEvoMax value="1.00000000"/>
+      <boatPropellerPtFxScale value="1.00000000"/>
+      <boatLowLodWakePtFxEnabled value="false"/>
+      <boatLowLodWakePtFxRangeMin value="40.00000000"/>
+      <boatLowLodWakePtFxRangeMax value="400.00000000"/>
+      <boatLowLodWakePtFxName/>
+      <boatLowLodWakePtFxSpeedEvoMin value="0.00000000"/>
+      <boatLowLodWakePtFxSpeedEvoMax value="10.00000000"/>
+      <boatLowLodWakePtFxScale value="1.00000000"/>
+      <planeAfterburnerPtFxEnabled value="false"/>
+      <planeAfterburnerPtFxName/>
+      <planeAfterburnerPtFxRange value="100.00000000"/>
+      <planeAfterburnerPtFxScale value="1.00000000"/>
+      <planeWingTipPtFxEnabled value="false"/>
+      <planeWingTipPtFxName/>
+      <planeWingTipPtFxRange value="100.00000000"/>
+      <planeWingTipPtFxSpeedEvoMin value="0.00000000"/>
+      <planeWingTipPtFxSpeedEvoMax value="1.00000000"/>
+      <planeDamageFirePtFxEnabled value="false"/>
+      <planeDamageFirePtFxName/>
+      <planeDamageFirePtFxRange value="100.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMin value="0.00000000"/>
+      <planeDamageFirePtFxSpeedEvoMax value="20.00000000"/>
+      <planeGroundDisturbPtFxEnabled value="false"/>
+      <planeGroundDisturbPtFxNameDefault/>
+      <planeGroundDisturbPtFxNameSand/>
+      <planeGroundDisturbPtFxNameDirt/>
+      <planeGroundDisturbPtFxNameWater/>
+      <planeGroundDisturbPtFxNameFoliage/>
+      <planeGroundDisturbPtFxRange value="70.00000000"/>
+      <planeGroundDisturbPtFxDist value="20.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMin value="0.00000000"/>
+      <planeGroundDisturbPtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftSectionDamageSmokePtFxEnabled value="false"/>
+      <aircraftSectionDamageSmokePtFxName/>
+      <aircraftSectionDamageSmokePtFxRange value="100.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftSectionDamageSmokePtFxSpeedEvoMax value="20.00000000"/>
+      <aircraftDownwashPtFxEnabled value="false"/>
+      <aircraftDownwashPtFxNameDefault/>
+      <aircraftDownwashPtFxNameSand/>
+      <aircraftDownwashPtFxNameDirt/>
+      <aircraftDownwashPtFxNameWater/>
+      <aircraftDownwashPtFxNameFoliage/>
+      <aircraftDownwashPtFxRange value="70.00000000"/>
+      <aircraftDownwashPtFxDist value="20.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMin value="0.00000000"/>
+      <aircraftDownwashPtFxSpeedEvoMax value="20.00000000"/>
+      <splashInPtFxEnabled value="true"/>
+      <splashInPtFxRange value="100.00000000"/>
+      <splashInPtFxName>water_splash_veh_in</splashInPtFxName>
+      <splashInPtFxSizeEvoMax value="5.00000000"/>
+      <splashInPtFxSpeedDownwardThresh value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedLateralEvoMax value="18.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMin value="2.00000000"/>
+      <splashInPtFxSpeedDownwardEvoMax value="18.00000000"/>
+      <splashOutPtFxEnabled value="true"/>
+      <splashOutPtFxRange value="50.00000000"/>
+      <splashOutPtFxName>water_splash_veh_out</splashOutPtFxName>
+      <splashOutPtFxSizeEvoMax value="5.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedLateralEvoMax value="2.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMin value="0.00000000"/>
+      <splashOutPtFxSpeedUpwardEvoMax value="2.00000000"/>
+      <splashWadePtFxEnabled value="true"/>
+      <splashWadePtFxRange value="50.00000000"/>
+      <splashWadePtFxName>water_splash_veh_wade</splashWadePtFxName>
+      <splashWadePtFxSizeEvoMax value="5.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMin value="4.00000000"/>
+      <splashWadePtFxSpeedVehicleEvoMax value="15.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMin value="0.00000000"/>
+      <splashWadePtFxSpeedRiverEvoMax value="15.00000000"/>
+      <splashTrailPtFxEnabled value="true"/>
+      <splashTrailPtFxRange value="50.00000000"/>
+      <splashTrailPtFxName>water_splash_veh_trail</splashTrailPtFxName>
+      <splashTrailPtFxSizeEvoMax value="5.00000000"/>
+      <splashTrailPtFxSpeedEvoMin value="1.00000000"/>
+      <splashTrailPtFxSpeedEvoMax value="16.00000000"/>
+    </Item>
+  </vfxVehicleInfos>
+</CVfxVehicleInfoMgr>


### PR DESCRIPTION
This enables exhaust smoke on the BTTF exhaust.

`vfxvehicleinfo.ymt` is required to be modified to disable misfires and backfires.

This also sets the Dirt Level to zero upon spawning/script reloading.